### PR TITLE
Use core instead of std

### DIFF
--- a/enumflags/src/lib.rs
+++ b/enumflags/src/lib.rs
@@ -44,18 +44,14 @@
 //! ```
 #![warn(missing_docs)]
 #![no_std]
-#[cfg(not(feature = "nostd"))]
-extern crate std;
-#[cfg(feature = "nostd")]
-extern crate core as std;
 
-use std::fmt::{self, Formatter};
-use std::iter::FromIterator;
+use core::{fmt, cmp, ops};
+use core::iter::FromIterator;
 
 /// Sealed trait
 mod details {
-    use std::ops::{BitAnd, BitOr, BitXor, Not};
-    use std::cmp::PartialOrd;
+    use core::ops::{BitAnd, BitOr, BitXor, Not};
+    use core::cmp::PartialOrd;
 
     pub trait BitFlagNum
         : Default
@@ -84,7 +80,7 @@ where
     Self: RawBitFlags,
 {
     /// The implementation of Debug redirects here.
-    fn fmt(flags: BitFlags<Self>, f: &mut Formatter) -> fmt::Result;
+    fn fmt(flags: BitFlags<Self>, f: &mut fmt::Formatter) -> fmt::Result;
 }
 
 /// A trait automatically implemented by `derive(EnumFlags)` to make the enum a valid type parameter
@@ -110,11 +106,11 @@ pub struct BitFlags<T: RawBitFlags> {
     val: T::Type,
 }
 
-impl<T> ::std::fmt::Debug for BitFlags<T>
+impl<T> fmt::Debug for BitFlags<T>
 where
     T: RawBitFlags + BitFlagsFmt,
 {
-    fn fmt(&self, fmt: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
         T::fmt(self.clone(), fmt)
     }
 }
@@ -225,7 +221,7 @@ where
     }
 }
 
-impl<T, B> std::cmp::PartialEq<B> for BitFlags<T>
+impl<T, B> cmp::PartialEq<B> for BitFlags<T>
 where
     T: RawBitFlags,
     B: Into<BitFlags<T>> + Copy,
@@ -235,7 +231,7 @@ where
     }
 }
 
-impl<T, B> std::ops::BitOr<B> for BitFlags<T>
+impl<T, B> ops::BitOr<B> for BitFlags<T>
 where
     T: RawBitFlags,
     B: Into<BitFlags<T>>,
@@ -246,7 +242,7 @@ where
     }
 }
 
-impl<T, B> std::ops::BitAnd<B> for BitFlags<T>
+impl<T, B> ops::BitAnd<B> for BitFlags<T>
 where
     T: RawBitFlags,
     B: Into<BitFlags<T>>,
@@ -257,7 +253,7 @@ where
     }
 }
 
-impl<T, B> std::ops::BitXor<B> for BitFlags<T>
+impl<T, B> ops::BitXor<B> for BitFlags<T>
 where
     T: RawBitFlags,
     B: Into<BitFlags<T>>,
@@ -268,7 +264,7 @@ where
     }
 }
 
-impl<T, B> std::ops::BitOrAssign<B> for BitFlags<T>
+impl<T, B> ops::BitOrAssign<B> for BitFlags<T>
 where
     T: RawBitFlags,
     B: Into<BitFlags<T>>,
@@ -278,7 +274,7 @@ where
     }
 }
 
-impl<T, B> std::ops::BitAndAssign<B> for BitFlags<T>
+impl<T, B> ops::BitAndAssign<B> for BitFlags<T>
 where
     T: RawBitFlags,
     B: Into<BitFlags<T>>,
@@ -287,7 +283,7 @@ where
         *self = *self & other;
     }
 }
-impl<T, B> std::ops::BitXorAssign<B> for BitFlags<T>
+impl<T, B> ops::BitXorAssign<B> for BitFlags<T>
 where
     T: RawBitFlags,
     B: Into<BitFlags<T>>,
@@ -297,7 +293,7 @@ where
     }
 }
 
-impl<T> std::ops::Not for BitFlags<T>
+impl<T> ops::Not for BitFlags<T>
 where
     T: RawBitFlags,
 {

--- a/enumflags_derive/src/lib.rs
+++ b/enumflags_derive/src/lib.rs
@@ -165,19 +165,20 @@ fn gen_enumflags(ident: &Ident, item: &DeriveInput, data: &DataEnum) -> TokenStr
                     use ::enumflags2::RawBitFlags;
                     use #std_path::iter::Iterator;
                     const VARIANT_NAMES: [&'static str; #variants_len] = [#(#variants_names, )*];
-                    let vals =
+                    let mut vals =
                         VARIANTS.iter().zip(VARIANT_NAMES.iter())
                         .filter(|&(&val, _)| val as #ty & flags.bits() != 0)
                         .map(|(_, name)| name);
-                    write!(fmt, "BitFlags<{}>(0b{:b}, [",
+                    write!(fmt, "BitFlags<{}>(0b{:b}",
                            stringify!(#ident),
                            flags.bits())?;
-                    for (i, val) in vals.enumerate() {
-                        write!(fmt, "{}{}",
-                               if i == 0 { "" } else { ", " },
-                               val)?;
+                    if let #std_path::option::Option::Some(val) = vals.next() {
+                        write!(fmt, ", {}", val)?;
+                        for val in vals {
+                            write!(fmt, " | {}", val)?;
+                        }
                     }
-                    write!(fmt, "]) ")
+                    write!(fmt, ")")
                 }
             }
 

--- a/enumflags_derive/src/lib.rs
+++ b/enumflags_derive/src/lib.rs
@@ -137,16 +137,13 @@ fn gen_enumflags(ident: &Ident, item: &DeriveInput, data: &DataEnum) -> TokenStr
             data = wrong_flag_values
         )
     );
-    #[cfg(not(feature = "nostd"))]
-    let std_path = Ident::new("std", span);
-    #[cfg(feature = "nostd")]
-    let std_path = Ident::new("core", span);
+    let std_path = quote_spanned!(span=> self::core);
     let scope_ident = Ident::new(&format!("__scope_enumderive_{}",
                                           item.ident.to_string().to_lowercase()), span);
     quote_spanned!{
         span =>
         mod #scope_ident {
-            extern crate #std_path;
+            extern crate core;
             use super::#ident;
             impl #std_path::ops::Not for #ident {
                 type Output = ::enumflags2::BitFlags<#ident>;
@@ -175,7 +172,7 @@ fn gen_enumflags(ident: &Ident, item: &DeriveInput, data: &DataEnum) -> TokenStr
             impl #std_path::ops::BitXor for #ident {
                 type Output = ::enumflags2::BitFlags<#ident>;
                 fn bitxor(self, other: Self) -> Self::Output {
-                    Into::<Self::Output>::into(self) ^ Into::<Self::Output>::into(other)
+                    #std_path::convert::Into::<Self::Output>::into(self) ^ #std_path::convert::Into::<Self::Output>::into(other)
                 }
             }
 

--- a/test_suite/tests/no_implicit_prelude.rs
+++ b/test_suite/tests/no_implicit_prelude.rs
@@ -1,0 +1,21 @@
+#![no_implicit_prelude]
+
+extern crate enumflags2;
+#[macro_use]
+extern crate enumflags2_derive;
+
+#[derive(EnumFlags, Copy, Clone, Debug, PartialEq)]
+#[repr(u8)]
+pub enum Test {
+    A = 1 << 0,
+    B = 1 << 1,
+    C = 1 << 2,
+    D = 1 << 3,
+}
+
+#[test]
+fn test_foo() {
+    // assert!() doesn't even work in no_implicit_prelude!
+    use enumflags2::BitFlags;
+    let _ = BitFlags::<Test>::all();
+}

--- a/test_suite/tests/no_std.rs
+++ b/test_suite/tests/no_std.rs
@@ -1,0 +1,2 @@
+#![no_std]
+include!("bitflag_tests.rs");


### PR DESCRIPTION
An explicit feature seems unnecessary; the `#![no_std]` feature isn't `cfg_attr`'d so I assume the feature flag doesn't exist for the sake of a minimum rustc version. It seems simpler to just always use `core` like bitflags does.

Removing a feature from Cargo.toml is a bit of a breaking change though, so maybe those should be left in and just do nothing?