### PR TITLE
Re-export core via enumflags2

### DIFF
--- a/enumflags/Cargo.toml
+++ b/enumflags/Cargo.toml
@@ -9,9 +9,5 @@ readme = "../README.md"
 keywords = ["enum", "bitflag", "flag", "bitflags"]
 documentation = "https://docs.rs/enumflags2"
 
-[features]
-default = []
-nostd = []
-
 [dev-dependencies]
 enumflags2_derive = { version = "0.5.0", path = "../enumflags_derive" }

--- a/enumflags/src/lib.rs
+++ b/enumflags/src/lib.rs
@@ -48,6 +48,14 @@
 use core::{fmt, cmp, ops};
 use core::iter::FromIterator;
 
+// Re-export libcore so the macro doesn't inject "extern crate" downstream.
+#[doc(hidden)]
+pub mod _internal {
+    pub mod core {
+        pub use core::{convert, fmt, iter, option, ops};
+    }
+}
+
 /// Sealed trait
 mod details {
     use core::ops::{BitAnd, BitOr, BitXor, Not};

--- a/enumflags_derive/Cargo.toml
+++ b/enumflags_derive/Cargo.toml
@@ -14,7 +14,3 @@ proc-macro2 = "^1.0"
 
 [lib]
 proc-macro = true
-
-[features]
-default = []
-nostd = []

--- a/enumflags_derive/src/lib.rs
+++ b/enumflags_derive/src/lib.rs
@@ -116,13 +116,12 @@ fn gen_enumflags(ident: &Ident, item: &DeriveInput, data: &DataEnum) -> TokenStr
             data = wrong_flag_values
         )
     );
-    let std_path = quote_spanned!(span=> self::core);
+    let std_path = quote_spanned!(span=> ::enumflags2::_internal::core);
     let scope_ident = Ident::new(&format!("__scope_enumderive_{}",
                                           item.ident.to_string().to_lowercase()), span);
     quote_spanned!{
         span =>
         mod #scope_ident {
-            extern crate core;
             use super::#ident;
 
             const VARIANTS: [#ident; #variants_len] = [#(#names :: #variants, )*];


### PR DESCRIPTION
Builds on top of #4, with the breaking changes isolated here so the initial PR can still be part of 0.5.x.

Rationale in the comment TBD once we figure out the real reason for doing this (if it is actually desireable to do so), see previous PR for discussion regarding the pros/cons of injecting `extern crate core` via the macro vs re-exporting.