### PR TITLE
Debug impl changes

### DIFF
--- a/enumflags/src/formatting.rs
+++ b/enumflags/src/formatting.rs
@@ -1,0 +1,80 @@
+use core::fmt::{self, Debug, Binary};
+
+// Format an iterator of flags into "A | B | etc"
+pub struct FlagFormatter<I>(pub I);
+
+impl<T: Debug, I: Clone + Iterator<Item=T>> Debug for FlagFormatter<I> {
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        let mut iter = self.0.clone();
+        if let Some(val) = iter.next() {
+            Debug::fmt(&val, fmt)?;
+            for val in iter {
+                fmt.write_str(" | ")?;
+                Debug::fmt(&val, fmt)?;
+            }
+            Ok(())
+        } else {
+            // convention would print "<empty>" or similar here, but this is an
+            // internal API that is never called that way, so just do nothing.
+            Ok(())
+        }
+    }
+}
+
+// A formatter that obeys format arguments but falls back to binary when
+// no explicit format is requested. Supports {:08?}, {:08x?}, etc.
+pub struct DebugBinaryFormatter<'a, F>(pub &'a F);
+
+impl<'a, F: Debug + Binary + 'a> Debug for DebugBinaryFormatter<'a, F> {
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        // Check if {:x?} or {:X?} was used; this is determined via the
+        // discriminator of core::fmt::FlagV1::{DebugLowerHex, DebugUpperHex},
+        // which is not an accessible type: https://github.com/rust-lang/rust/blob/d65e272a9fe3e61aa5f229c5358e35a909435575/src/libcore/fmt/mod.rs#L306
+        // See also: https://github.com/rust-lang/rfcs/pull/2226
+        #[allow(deprecated)]
+        let format_hex = fmt.flags() >> 4;
+        let width = fmt.width().unwrap_or(0);
+
+        if format_hex & 1 != 0 { // FlagV1::DebugLowerHex
+            write!(fmt, "{:#0width$x?}", &self.0, width = width)
+        } else if format_hex & 2 != 0 { // FlagV1::DebugUpperHex
+            write!(fmt, "{:#0width$X?}", &self.0, width = width)
+        } else {
+            // Fall back to binary otheriwse
+            write!(fmt, "{:#0width$b}", &self.0, width = width)
+        }
+    }
+}
+
+#[test]
+fn flag_formatter() {
+    use core::iter;
+
+    macro_rules! assert_fmt {
+        ($fmt:expr, $expr:expr, $expected:expr) => {
+            assert_eq!(format!($fmt, FlagFormatter($expr)), $expected)
+        };
+    }
+
+    assert_fmt!("{:?}", iter::empty::<u8>(), "");
+    assert_fmt!("{:?}", iter::once(1), "1");
+    assert_fmt!("{:?}", [1, 2].iter(), "1 | 2");
+    assert_fmt!("{:?}", [1, 2, 10].iter(), "1 | 2 | 10");
+    assert_fmt!("{:02x?}", [1, 2, 10].iter(), "01 | 02 | 0a");
+    assert_fmt!("{:#04X?}", [1, 2, 10].iter(), "0x01 | 0x02 | 0x0A");
+}
+
+#[test]
+fn debug_binary_formatter() {
+    macro_rules! assert_fmt {
+        ($fmt:expr, $expr:expr, $expected:expr) => {
+            assert_eq!(format!($fmt, DebugBinaryFormatter(&$expr)), $expected)
+        };
+    }
+
+    assert_fmt!("{:?}", 10, "0b1010");
+    assert_fmt!("{:#?}", 10, "0b1010");
+    assert_fmt!("{:010?}", 10, "0b00001010");
+    assert_fmt!("{:010x?}", 10, "0x0000000a");
+    assert_fmt!("{:#010X?}", 10, "0x0000000A");
+}

--- a/enumflags/src/lib.rs
+++ b/enumflags/src/lib.rs
@@ -153,6 +153,46 @@ where
     }
 }
 
+impl<T> fmt::Binary for BitFlags<T>
+where
+    T: RawBitFlags,
+    T::Type: fmt::Binary,
+{
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        fmt::Binary::fmt(&self.bits(), fmt)
+    }
+}
+
+impl<T> fmt::Octal for BitFlags<T>
+where
+    T: RawBitFlags,
+    T::Type: fmt::Octal,
+{
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        fmt::Octal::fmt(&self.bits(), fmt)
+    }
+}
+
+impl<T> fmt::LowerHex for BitFlags<T>
+where
+    T: RawBitFlags,
+    T::Type: fmt::LowerHex,
+{
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        fmt::LowerHex::fmt(&self.bits(), fmt)
+    }
+}
+
+impl<T> fmt::UpperHex for BitFlags<T>
+where
+    T: RawBitFlags,
+    T::Type: fmt::UpperHex,
+{
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        fmt::UpperHex::fmt(&self.bits(), fmt)
+    }
+}
+
 /// The default value returned is one with all flags unset, i. e. [`empty`][Self::empty].
 impl<T> Default for BitFlags<T>
 where

--- a/example/src/main.rs
+++ b/example/src/main.rs
@@ -2,7 +2,7 @@ extern crate enumflags2;
 #[macro_use]
 extern crate enumflags2_derive;
 use enumflags2::*;
-#[derive(EnumFlags, Copy, Clone)]
+#[derive(EnumFlags, Copy, Clone, Debug)]
 #[repr(u8)]
 pub enum Test {
     A = 0b0001,

--- a/test_suite/Cargo.toml
+++ b/test_suite/Cargo.toml
@@ -37,3 +37,8 @@ edition = "2018"
 name = "bitflags-test-no-implicit-prelude-2018"
 path = "tests/no_implicit_prelude_2018.rs"
 edition = "2018"
+
+[[test]]
+name = "bitflags-formatting"
+path = "tests/formatting.rs"
+edition = "2018"

--- a/test_suite/tests/formatting.rs
+++ b/test_suite/tests/formatting.rs
@@ -1,0 +1,74 @@
+use enumflags2_derive::EnumFlags;
+
+include!("../common.rs");
+
+#[test]
+fn debug_format() {
+    use enumflags2::BitFlags;
+
+    // Assert that our Debug output format meets expectations
+
+    assert_eq!(
+        format!("{:?}", BitFlags::<Test>::all()),
+        "BitFlags<Test>(0b1111, A | B | C | D)"
+    );
+
+    assert_eq!(
+        format!("{:?}", BitFlags::<Test>::empty()),
+        "BitFlags<Test>(0b0)"
+    );
+
+    assert_eq!(
+        format!("{:04x?}", BitFlags::<Test>::all()),
+        "BitFlags<Test>(0x0f, A | B | C | D)"
+    );
+
+    assert_eq!(
+        format!("{:04X?}", BitFlags::<Test>::all()),
+        "BitFlags<Test>(0x0F, A | B | C | D)"
+    );
+
+    // Also check alternate struct formatting
+
+    assert_eq!(
+        format!("{:#010?}", BitFlags::<Test>::all()),
+"BitFlags<Test> {
+    bits: 0b00001111,
+    flags: A | B | C | D,
+}"
+    );
+
+    assert_eq!(
+        format!("{:#?}", BitFlags::<Test>::empty()),
+"BitFlags<Test> {
+    bits: 0b0,
+}"
+    );
+}
+
+#[test]
+fn format() {
+    use enumflags2::BitFlags;
+
+    // Assert BitFlags<T> impls fmt::{Binary, Octal, LowerHex, UpperHex}
+
+    assert_eq!(
+        format!("{:b}", BitFlags::<Test>::all()),
+        "1111"
+    );
+
+    assert_eq!(
+        format!("{:o}", BitFlags::<Test>::all()),
+        "17"
+    );
+
+    assert_eq!(
+        format!("{:x}", BitFlags::<Test>::all()),
+        "f"
+    );
+
+    assert_eq!(
+        format!("{:#04X}", BitFlags::<Test>::all()),
+        "0x0F"
+    );
+}


### PR DESCRIPTION
This is a common `Debug` implementation with a lot less codegen per enum required. You can now use format specifiers like `{:02x?}` to get `BitFlags<T>(0x03, A | B)`, and custom `Debug` impls for the enum will be used in place of `A` or `B` if used.

The internal `BitFlagsFmt` trait has been removed and replaced with a `bitflags_type_name()` method to get the same old `BitFlags<T>(...)` behaviour. A consequence of this is that the enum types must now be explicitly annotated with `#[derive(Debug)]` in order for debug to work.