### PR TITLE
Test flags that span multiple bits

### DIFF
--- a/test_suite/common.rs
+++ b/test_suite/common.rs
@@ -90,3 +90,32 @@ fn assign_ops() {
     x ^= Test::B | Test::C;
     assert_eq!(x, Test::A | Test::C);
 }
+
+#[derive(EnumFlags, Copy, Clone, Debug, PartialEq)]
+#[repr(u8)]
+enum TestM {
+    A = 0b001,
+    B = 0b110,
+}
+
+#[test]
+fn multibit_from() {
+    use enumflags2::BitFlags;
+    assert_eq!(
+        BitFlags::<TestM>::all(),
+        TestM::A | TestM::B
+    );
+    assert_eq!(
+        BitFlags::<TestM>::from_bits_truncate(0b011),
+        TestM::A
+    );
+}
+
+#[test]
+fn multibit_truncate() {
+    use enumflags2::BitFlags;
+    assert_eq!(
+        BitFlags::<TestM>::from_bits(0b011),
+        None
+    );
+}


### PR DESCRIPTION
(both tests currently fail)

My assumption is that this test should be valid and the implementation of `from_bits` / `from_bits_truncate` is incorrect? An alternate interpretation might be that each flag should never be more than one bit, though that seems like an odd constraint to me.