### PR TITLE
Test items defined inside a function

### DIFF
--- a/enumflags_derive/src/lib.rs
+++ b/enumflags_derive/src/lib.rs
@@ -116,15 +116,8 @@ fn gen_enumflags(ident: &Ident, item: &DeriveInput, data: &DataEnum) -> TokenStr
         )
     );
     let std_path = quote_spanned!(span=> ::enumflags2::_internal::core);
-    let scope_ident = Ident::new(&format!("__scope_enumderive_{}",
-                                          item.ident.to_string().to_lowercase()), span);
     quote_spanned!{
         span =>
-        mod #scope_ident {
-            use super::#ident;
-
-            const VARIANTS: [#ident; #variants_len] = [#(#names :: #variants, )*];
-
             impl #std_path::ops::Not for #ident {
                 type Output = ::enumflags2::BitFlags<#ident>;
                 fn not(self) -> Self::Output {
@@ -168,6 +161,7 @@ fn gen_enumflags(ident: &Ident, item: &DeriveInput, data: &DataEnum) -> TokenStr
                 }
 
                 fn flag_list() -> &'static [Self] {
+                    const VARIANTS: [#ident; #variants_len] = [#(#names :: #variants, )*];
                     &VARIANTS
                 }
 
@@ -175,6 +169,5 @@ fn gen_enumflags(ident: &Ident, item: &DeriveInput, data: &DataEnum) -> TokenStr
                     concat!("BitFlags<", stringify!(#ident), ">")
                 }
             }
-        }
     }
 }

--- a/test_suite/common.rs
+++ b/test_suite/common.rs
@@ -90,3 +90,12 @@ fn assign_ops() {
     x ^= Test::B | Test::C;
     assert_eq!(x, Test::A | Test::C);
 }
+
+#[test]
+fn fn_derive() {
+    #[derive(EnumFlags, Copy, Clone, Debug)]
+    #[repr(u8)]
+    enum TestFn {
+        A = 1 << 0,
+    }
+}


### PR DESCRIPTION
(currently does not compile)

The trait impls should presumably be moved outside of the derive `__scope` module, now that we're re-exporting core I think it should be okay to remove that module entirely from the codegen?