### PR TITLE
Optional serde impls for BitFlags<T>

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ extern crate enumflags2;
 - [x] Has a similar API compared to the popular [bitflags](https://crates.io/crates/bitflags) crate.
 - [x] Does not expose the generated types explicity. The user interacts exclusively with `struct BitFlags<Enum>;`.
 - [x] The debug formatter prints the binary flag value as well as the flag enums: `BitFlags(0b1111, [A, B, C, D])`.
+- [x] Optional support for serialization with the [`serde`](https://serde.rs/) feature flag.
 
 ### Example
 

--- a/enumflags/Cargo.toml
+++ b/enumflags/Cargo.toml
@@ -11,3 +11,4 @@ documentation = "https://docs.rs/enumflags2"
 
 [dependencies]
 enumflags2_derive = { version = "0.6.0", path = "../enumflags_derive" }
+serde = { version = "^1.0.0", default-features = false, optional = true }

--- a/enumflags/src/lib.rs
+++ b/enumflags/src/lib.rs
@@ -40,6 +40,10 @@
 //!     assert!(!(a_b.intersects(Test::C | Test::D)));
 //! }
 //! ```
+//!
+//! ## Optional Feature Flags
+//!
+//! - [`serde`](https://serde.rs/) implements `Serialize` and `Deserialize` for `BitFlags<T>`.
 #![warn(missing_docs)]
 #![cfg_attr(not(test), no_std)]
 


### PR DESCRIPTION
I feel like serde is a big enough crate to warrant this? Bitflags are often used when interop'ing with data from external contexts, and serde is often used for {de,}serializing external data, so...