### PR TITLE
impl TryFrom<T::Type> for BitFlags<T>

### DIFF
--- a/enumflags/Cargo.toml
+++ b/enumflags/Cargo.toml
@@ -12,3 +12,6 @@ documentation = "https://docs.rs/enumflags2"
 [dependencies]
 enumflags2_derive = { version = "0.6.0", path = "../enumflags_derive" }
 serde = { version = "^1.0.0", default-features = false, optional = true }
+
+[features]
+std = []

--- a/enumflags/src/fallible.rs
+++ b/enumflags/src/fallible.rs
@@ -1,0 +1,27 @@
+use core::convert::TryFrom;
+use super::{BitFlags, FromBitsError};
+use super::_internal::RawBitFlags;
+
+macro_rules! impl_try_from {
+    () => { };
+    ($ty:ty, $($tt:tt)*) => {
+        impl_try_from! { $ty }
+        impl_try_from! { $($tt)* }
+    };
+    ($ty:ty) => {
+        impl<T> TryFrom<$ty> for BitFlags<T>
+        where
+            T: RawBitFlags<Type=$ty>,
+        {
+            type Error = FromBitsError<T>;
+
+            fn try_from(bits: T::Type) -> Result<Self, Self::Error> {
+                Self::try_from_bits(bits)
+            }
+        }
+    };
+}
+
+impl_try_from! {
+    u8, u16, u32, u64, usize
+}

--- a/enumflags/src/fallible.rs
+++ b/enumflags/src/fallible.rs
@@ -1,4 +1,5 @@
 use core::convert::TryFrom;
+use core::fmt;
 use super::BitFlags;
 use super::_internal::RawBitFlags;
 
@@ -47,9 +48,15 @@ impl<T: RawBitFlags> FromBitsError<T> {
     }
 }
 
+impl<T: RawBitFlags + fmt::Debug> fmt::Display for FromBitsError<T> {
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        write!(fmt, "Invalid bits for {:?}: {:#b}", self.flags, self.invalid)
+    }
+}
+
 #[cfg(feature = "std")]
-impl<T: RawBitFlags> std::error::Error for FromBitsError<T> {
+impl<T: RawBitFlags + fmt::Debug> std::error::Error for FromBitsError<T> {
     fn description(&self) -> &str {
-        "invalid bit representation"
+        "invalid bitflags representation"
     }
 }

--- a/enumflags/src/fallible.rs
+++ b/enumflags/src/fallible.rs
@@ -3,30 +3,27 @@ use super::BitFlags;
 use super::_internal::RawBitFlags;
 
 macro_rules! impl_try_from {
-    () => { };
-    ($ty:ty, $($tt:tt)*) => {
-        impl_try_from! { $ty }
-        impl_try_from! { $($tt)* }
-    };
-    ($ty:ty) => {
-        impl<T> TryFrom<$ty> for BitFlags<T>
-        where
-            T: RawBitFlags<Type=$ty>,
-        {
-            type Error = FromBitsError<T>;
+    ($($ty:ty),*) => {
+        $(
+            impl<T> TryFrom<$ty> for BitFlags<T>
+            where
+                T: RawBitFlags<Type=$ty>,
+            {
+                type Error = FromBitsError<T>;
 
-            fn try_from(bits: T::Type) -> Result<Self, Self::Error> {
-                let flags = Self::from_bits_truncate(bits);
-                if flags.bits() == bits {
-                    Ok(flags)
-                } else {
-                    Err(FromBitsError {
-                        flags,
-                        invalid: bits & !flags.bits(),
-                    })
+                fn try_from(bits: T::Type) -> Result<Self, Self::Error> {
+                    let flags = Self::from_bits_truncate(bits);
+                    if flags.bits() == bits {
+                        Ok(flags)
+                    } else {
+                        Err(FromBitsError {
+                            flags,
+                            invalid: bits & !flags.bits(),
+                        })
+                    }
                 }
             }
-        }
+        )*
     };
 }
 

--- a/enumflags/src/formatting.rs
+++ b/enumflags/src/formatting.rs
@@ -1,5 +1,5 @@
 use core::fmt::{self, Debug, Binary};
-use crate::{BitFlags, _internal::RawBitFlags};
+use crate::{BitFlags, FromBitsError, _internal::RawBitFlags};
 
 impl<T> fmt::Debug for BitFlags<T>
 where

--- a/enumflags/src/formatting.rs
+++ b/enumflags/src/formatting.rs
@@ -1,5 +1,5 @@
 use core::fmt::{self, Debug, Binary};
-use crate::{BitFlags, FromBitsError, _internal::RawBitFlags};
+use crate::{BitFlags, _internal::RawBitFlags};
 
 impl<T> fmt::Debug for BitFlags<T>
 where

--- a/enumflags/src/formatting.rs
+++ b/enumflags/src/formatting.rs
@@ -4,7 +4,6 @@ use crate::{BitFlags, _internal::RawBitFlags};
 impl<T> fmt::Debug for BitFlags<T>
 where
     T: RawBitFlags + fmt::Debug,
-    T::Type: fmt::Binary + fmt::Debug,
 {
     fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
         let name = T::bitflags_type_name();

--- a/enumflags/src/lib.rs
+++ b/enumflags/src/lib.rs
@@ -122,6 +122,7 @@ mod formatting;
 
 // impl TryFrom<T::Type> for BitFlags<T>
 mod fallible;
+pub use fallible::FromBitsError;
 
 use _internal::RawBitFlags;
 
@@ -210,18 +211,6 @@ where
 
     pub fn from_flag(t: T) -> Self {
         BitFlags { val: t.bits() }
-    }
-
-    pub fn try_from_bits(bits: T::Type) -> Result<Self, FromBitsError<T>> {
-        let flags = Self::from_bits_truncate(bits);
-        if flags.bits() == bits {
-            Ok(flags)
-        } else {
-            Err(FromBitsError {
-                flags,
-                invalid: bits & !flags.bits(),
-            })
-        }
     }
 
     /// Truncates flags that are illegal
@@ -379,28 +368,5 @@ mod impl_serde {
         fn serialize<S: serde::Serializer>(&self, s: S) -> Result<S::Ok, S::Error> {
             T::Type::serialize(&self.val, s)
         }
-    }
-}
-
-#[derive(Debug, Copy, Clone)]
-pub struct FromBitsError<T: RawBitFlags> {
-    flags: BitFlags<T>,
-    invalid: T::Type,
-}
-
-impl<T: RawBitFlags> FromBitsError<T> {
-    pub fn truncate(self) -> BitFlags<T> {
-        self.flags
-    }
-
-    pub fn invalid_bits(self) -> T::Type {
-        self.invalid
-    }
-}
-
-#[cfg(feature = "std")]
-impl<T: RawBitFlags> std::error::Error for FromBitsError<T> {
-    fn description(&self) -> &str {
-        "invalid bit representation"
     }
 }

--- a/enumflags/src/lib.rs
+++ b/enumflags/src/lib.rs
@@ -89,6 +89,7 @@ pub mod _internal {
 
     use core::ops::{BitAnd, BitOr, BitXor, Not};
     use core::cmp::PartialOrd;
+    use core::fmt;
 
     pub trait BitFlagNum
         : Default
@@ -97,6 +98,8 @@ pub mod _internal {
         + BitXor<Self, Output = Self>
         + Not<Output = Self>
         + PartialOrd<Self>
+        + fmt::Debug
+        + fmt::Binary
         + Copy
         + Clone {
     }

--- a/enumflags/src/lib.rs
+++ b/enumflags/src/lib.rs
@@ -48,7 +48,7 @@
 #![warn(missing_docs)]
 #![cfg_attr(all(not(test), not(feature = "std")), no_std)]
 
-#[cfg(all(test, not(feature = "std")))]
+#[cfg(any(test, feature = "std"))]
 extern crate core;
 use core::{cmp, ops};
 use core::iter::FromIterator;

--- a/test_suite/tests/formatting.rs
+++ b/test_suite/tests/formatting.rs
@@ -72,3 +72,13 @@ fn format() {
         "0x0F"
     );
 }
+
+#[test]
+fn debug_generic() {
+    use enumflags2::{BitFlags, _internal::RawBitFlags};
+
+    #[derive(Debug)]
+    struct Debug<T: RawBitFlags>(BitFlags<T>);
+
+    let _ = format!("{:?}", Debug(BitFlags::<Test>::all()));
+}


### PR DESCRIPTION
Misc notes:
- Submitting this for initial feedback on the approach, still needs documentation and tests
- This raises the minimum rustc version to 1.34.0 (from 1.31.0 currently due to syn 1.0 I think?). If that's too recent we could gate this behind a feature flag instead.
- This adds a `std` flag because although `TryFrom` doesn't have a `type Error: std::error::Error` bound, it's often useful to have that impl. I'm wary of making it default though, because it still seems ideal to keep the core crate `no_std` by default?
    - (I'm personally wary of any default Cargo flags in general because it feels way too easy for a dependency to not realise when it should be using `default-features = false`)
- Hard-codes the list of numeric types because [generic/blanket impls don't mesh well with TryFrom](https://github.com/rust-lang/rust/issues/50133). I was hoping the proc macro impl'ing it for `BitFlags<Self>` might work but that's not good enough for the orphan rules it seems.
- `BitFlagNum` modified to include `fmt::Debug` constraint because we kind of want `#[derive(Debug)] struct S<T>(BitFlags<T>)` to work?
    - This is making me think about generic `BitFlags<T>` in context though... We hide `BitFlagsRaw` as an internal trait despite the fact that it's required for `BitFlags<T>` and thus pretty crucial for doing any generic operations over bitflags... I'm questioning whether we shouldn't re-export this publicly at the root of the crate? (if we don't want manual impls and want to still require use of the proc macro, we can still make the trait fns themselves `doc(hidden)`)
    - There are a few points around the ergonomics of `BitFlags<T>` vs `T` that I'd like to address I think... Hm.