### PR TITLE
An experiment

### DIFF
--- a/enumflags/src/ext.rs
+++ b/enumflags/src/ext.rs
@@ -1,0 +1,70 @@
+use super::{BitFlag, EnumFlags, EnumFlagsConst};
+use super::repr::BitFlagRepr;
+
+pub trait BitFlagExt
+    : BitFlag
+{
+    #[inline]
+    fn into_flags(self) -> Self::Flags {
+        Self::Flags::from_flag(self)
+    }
+
+    #[inline]
+    /// Return the bits as a number type.
+    fn into_bits(self) -> Self::Type {
+        self.into_repr()
+    }
+
+    #[inline]
+    fn from_bit(bit: Self::Type) -> Option<Self> {
+        Self::from_repr(bit).ok()
+    }
+
+    #[inline]
+    fn try_from_bit(bit: Self::Type) -> Result<Self, Self::Type> {
+        Self::from_repr(bit)
+    }
+
+    #[inline]
+    unsafe fn from_bit_unchecked(bit: Self::Type) -> Self {
+        Self::from_repr_unchecked(bit)
+    }
+
+    #[inline]
+    fn from_bits(bits: Self::Type) -> Option<Self::Flags> {
+        Self::Flags::from_bits(bits)
+    }
+
+    #[inline]
+    fn try_from_bits(bits: Self::Type) -> Result<Self::Flags, Self::Type> {
+        Self::Flags::from_repr(bits)
+    }
+
+    #[inline]
+    fn from_bits_truncate(bits: Self::Type) -> Self::Flags {
+        Self::Flags::from_bits_truncate(bits)
+    }
+
+    #[inline]
+    unsafe fn from_bits_unchecked(bits: Self::Type) -> Self::Flags {
+        Self::Flags::from_repr_unchecked(bits)
+    }
+}
+
+impl<T: BitFlag> BitFlagExt for T { }
+
+pub trait BitFlagExtConst
+    : BitFlag
+{
+    const ALL: Self::Flags;
+
+    const EMPTY: Self::Flags;
+}
+
+impl<T: BitFlag> BitFlagExtConst for T
+where
+    T::Flags: EnumFlagsConst,
+{
+    const ALL: Self::Flags = Self::Flags::ALL;
+    const EMPTY: Self::Flags = Self::Flags::EMPTY;
+}

--- a/enumflags/src/formatting.rs
+++ b/enumflags/src/formatting.rs
@@ -1,9 +1,9 @@
 use core::fmt::{self, Debug, Binary};
-use crate::{BitFlags, _internal::RawBitFlags};
+use crate::{BitFlags, BitFlag, EnumFlags};
 
 impl<T> fmt::Debug for BitFlags<T>
 where
-    T: RawBitFlags + fmt::Debug,
+    T: BitFlag + fmt::Debug,
     T::Type: fmt::Binary + fmt::Debug,
 {
     fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
@@ -38,7 +38,7 @@ where
 
 impl<T> fmt::Binary for BitFlags<T>
 where
-    T: RawBitFlags,
+    T: BitFlag,
     T::Type: fmt::Binary,
 {
     fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
@@ -48,7 +48,7 @@ where
 
 impl<T> fmt::Octal for BitFlags<T>
 where
-    T: RawBitFlags,
+    T: BitFlag,
     T::Type: fmt::Octal,
 {
     fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
@@ -58,7 +58,7 @@ where
 
 impl<T> fmt::LowerHex for BitFlags<T>
 where
-    T: RawBitFlags,
+    T: BitFlag,
     T::Type: fmt::LowerHex,
 {
     fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
@@ -68,7 +68,7 @@ where
 
 impl<T> fmt::UpperHex for BitFlags<T>
 where
-    T: RawBitFlags,
+    T: BitFlag,
     T::Type: fmt::UpperHex,
 {
     fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {

--- a/enumflags/src/lib.rs
+++ b/enumflags/src/lib.rs
@@ -44,7 +44,7 @@
 //! ## Optional Feature Flags
 //!
 //! - [`serde`](https://serde.rs/) implements `Serialize` and `Deserialize` for `BitFlags<T>`.
-#![warn(missing_docs)]
+//#![warn(missing_docs)]
 #![cfg_attr(not(test), no_std)]
 
 #[cfg(test)]

--- a/enumflags/src/repr.rs
+++ b/enumflags/src/repr.rs
@@ -1,0 +1,63 @@
+use super::BitFlag;
+use core::cmp;
+use core::ops::{Not,
+    BitAnd, BitOr, BitXor,
+    BitAndAssign, BitOrAssign, BitXorAssign,
+};
+
+/// A raw representation of a set of `BitFlag`s
+pub trait BitFlagNum
+    : Default
+    + BitOr<Self, Output = Self>
+    + BitOrAssign<Self>
+    + BitAnd<Self, Output = Self>
+    + BitAndAssign<Self>
+    + BitXor<Self, Output = Self>
+    + BitXorAssign<Self>
+    + Not<Output = Self>
+    + cmp::PartialOrd<Self>
+    + Copy
+    + Clone
+{
+    const EMPTY: Self;
+}
+
+impl BitFlagNum for u8 { const EMPTY: Self = 0; }
+impl BitFlagNum for u16 { const EMPTY: Self = 0; }
+impl BitFlagNum for u32 { const EMPTY: Self = 0; }
+impl BitFlagNum for u64 { const EMPTY: Self = 0; }
+impl BitFlagNum for usize { const EMPTY: Self = 0; }
+
+/// A representation of a flag or set of `BitFlag`s
+///
+/// Implementing this trait is unsafe because it must only return
+/// bit patterns that represent a valid set of `T` flags.
+pub unsafe trait BitFlagRepr<T: BitFlag>
+    : Sized
+{
+    #[inline]
+    fn into_repr(self) -> T::Type { self.get_repr() }
+    fn from_repr(repr: T::Type) -> Result<Self, T::Type>;
+    unsafe fn from_repr_unchecked(repr: T::Type) -> Self;
+
+    fn get_repr(&self) -> T::Type;
+
+    unsafe fn set_repr(&mut self, val: T::Type) -> bool {
+        if let Ok(s) = Self::from_repr(val) {
+            *self = s;
+            true
+        } else {
+            false
+        }
+    }
+
+    #[inline]
+    unsafe fn set_repr_unchecked(&mut self, val: T::Type) {
+        *self = Self::from_repr_unchecked(val)
+    }
+
+    #[inline]
+    fn contains_repr(&self, r: T::Type) -> bool {
+        self.get_repr() & r == r
+    }
+}

--- a/enumflags_derive/src/lib.rs
+++ b/enumflags_derive/src/lib.rs
@@ -121,32 +121,60 @@ fn gen_enumflags(ident: &Ident, item: &DeriveInput, data: &DataEnum) -> TokenStr
             impl #std_path::ops::Not for #ident {
                 type Output = <Self as ::enumflags2::BitFlag>::Flags;
                 fn not(self) -> Self::Output {
-                    use ::enumflags2::{BitFlag, EnumFlags};
-                    unsafe { BitFlags::new(self.bits()).not() }
+                    use ::enumflags2::{BitFlagExt, EnumFlags};
+                    self.into_flags().not()
                 }
             }
 
             impl #std_path::ops::BitOr for #ident {
                 type Output = <Self as ::enumflags2::BitFlag>::Flags;
                 fn bitor(self, other: Self) -> Self::Output {
-                    use ::enumflags2::{BitFlag, EnumFlags};
-                    unsafe { BitFlags::new(self.bits() | other.bits())}
+                    use ::enumflags2::{BitFlagExt, EnumFlags};
+                    self.into_flags() | other
                 }
             }
 
             impl #std_path::ops::BitAnd for #ident {
                 type Output = <Self as ::enumflags2::BitFlag>::Flags;
                 fn bitand(self, other: Self) -> Self::Output {
-                    use ::enumflags2::{BitFlag, EnumFlags};
-                    unsafe { BitFlags::new(self.bits() & other.bits())}
+                    use ::enumflags2::{BitFlagExt, EnumFlags};
+                    self.into_flags() & other
                 }
             }
 
             impl #std_path::ops::BitXor for #ident {
                 type Output = <Self as ::enumflags2::BitFlag>::Flags;
                 fn bitxor(self, other: Self) -> Self::Output {
-                    use ::enumflags2::{BitFlags, EnumFlags};
-                    BitFlags::from_flag(self) ^ BitFlags::from_flag(other)
+                    use ::enumflags2::{BitFlagExt, EnumFlags};
+                    self.into_flags() ^ other
+                }
+            }
+
+            unsafe impl ::enumflags2::repr::BitFlagRepr<#ident> for #ident {
+                #[inline]
+                fn into_repr(self) -> #ty {
+                    self as #ty
+                }
+
+                #[inline]
+                fn get_repr(&self) -> #ty {
+                    *self as #ty
+                }
+
+                fn from_repr(bits: #ty) -> #std_path::result::Result<Self, #ty> {
+                    use ::enumflags2::BitFlag;
+                    use #std_path::result::Result;
+                    if bits & !Self::ALL_BITS == 0 && bits.count_ones() == 1 {
+                        // NOTE: avoid a match by relying on the invariant that
+                        //       a flag may not contain more than one bit
+                        Result::Ok(unsafe { Self::from_repr_unchecked(bits) })
+                    } else {
+                        Result::Err(bits)
+                    }
+                }
+
+                unsafe fn from_repr_unchecked(bits: #ty) -> Self {
+                    #std_path::mem::transmute(bits)
                 }
             }
 
@@ -154,25 +182,7 @@ fn gen_enumflags(ident: &Ident, item: &DeriveInput, data: &DataEnum) -> TokenStr
                 type Type = #ty;
                 type Flags = ::enumflags2::BitFlags<Self>;
 
-                #[inline]
-                fn all() -> Self::Type {
-                    /*fn _assert_blanket<T: ::enumflags2::BitFlagBlanket>() {
-                        // check that we implement all the required traits for a BitFlag
-                        _assert_blanket::<#ident>()
-                    }*/
-
-                    (#(#flag_values)|*) as #ty
-                }
-
-                #[inline]
-                fn bits(self) -> Self::Type {
-                    self as #ty
-                }
-
-                #[inline]
-                fn into_flags(self) -> Self::Flags {
-                    ::enumflags2::BitFlags::from_flag(self)
-                }
+                const ALL_BITS: Self::Type = (#(#flag_values)|*) as #ty;
 
                 #[inline]
                 fn flag_list() -> &'static [Self] {

--- a/test_suite/common.rs
+++ b/test_suite/common.rs
@@ -19,25 +19,25 @@ enum Test1 {
 
 #[test]
 fn test_foo() {
-    use enumflags2::BitFlags;
+    use enumflags2::*;
     assert_eq!(
-        BitFlags::<Test>::all(),
+        Test::ALL,
         Test::A | Test::B | Test::C | Test::D
     );
-    assert_eq!(BitFlags::<Test>::all() & Test::A, Test::A);
+    assert_eq!(Test::ALL & Test::A, Test::A);
     assert_eq!(!Test::A, Test::B | Test::C | Test::D);
     assert_eq!((Test::A | Test::C) ^ (Test::C | Test::B), Test::A | Test::B);
-    assert_eq!(BitFlags::<Test>::from_bits_truncate(4), Test::C);
-    assert_eq!(BitFlags::<Test>::from_bits_truncate(5), Test::A | Test::C);
+    assert_eq!(Test::from_bits_truncate(4), Test::C);
+    assert_eq!(Test::from_bits_truncate(5), Test::A | Test::C);
     assert_eq!(
-        BitFlags::<Test>::from_bits_truncate(16),
-        BitFlags::<Test>::empty()
+        Test::from_bits_truncate(16),
+        Test::EMPTY
     );
-    assert_eq!(BitFlags::<Test>::from_bits_truncate(17), Test::A);
-    assert_eq!(BitFlags::<Test>::from_bits(17), None);
+    assert_eq!(Test::from_bits_truncate(17), Test::A);
+    assert_eq!(Test::from_bits(17), None);
     assert_eq!(
-        BitFlags::<Test>::from_bits(15),
-        Some(BitFlags::<Test>::all())
+        Test::from_bits(15),
+        Some(Test::ALL)
     );
     {
         let mut b = Test::A | Test::B;
@@ -51,7 +51,7 @@ fn test_foo() {
     assert_eq!(!(Test::A | Test::B), Test::C | Test::D);
     assert_eq!((Test::A | Test::B).bits(), 3);
     assert_eq!((!(Test::A | Test::B)).bits(), 12);
-    assert_eq!(BitFlags::<Test>::all().bits(), 15);
+    assert_eq!(Test::ALL.bits(), 15);
     {
         let mut b = Test::A | Test::B | Test::C;
         b.remove(Test::B);
@@ -62,16 +62,13 @@ fn test_foo() {
 
 #[test]
 fn iterator() {
-    use enumflags2::BitFlags;
+    use enumflags2::*;
 
-    // it's a separate statement because type ascription is nightly
-    let tests: &[(BitFlags<Test>, &[Test])] = &[
-        (BitFlags::empty(), &[]),
+    for &(bitflag, expected) in &[
+        (Test::EMPTY, &[][..]),
         (Test::A.into(), &[Test::A]),
         (Test::A | Test::B, &[Test::A, Test::B]),
-    ];
-
-    for &(bitflag, expected) in tests {
+    ] {
         assert!(bitflag.iter().zip(expected.iter().cloned()).all(|(a, b)| a == b));
     }
 }

--- a/test_suite/tests/formatting.rs
+++ b/test_suite/tests/formatting.rs
@@ -4,34 +4,34 @@ include!("../common.rs");
 
 #[test]
 fn debug_format() {
-    use enumflags2::BitFlags;
+    use enumflags2::BitFlagExtConst;
 
     // Assert that our Debug output format meets expectations
 
     assert_eq!(
-        format!("{:?}", BitFlags::<Test>::all()),
+        format!("{:?}", Test::ALL),
         "BitFlags<Test>(0b1111, A | B | C | D)"
     );
 
     assert_eq!(
-        format!("{:?}", BitFlags::<Test>::empty()),
+        format!("{:?}", Test::EMPTY),
         "BitFlags<Test>(0b0)"
     );
 
     assert_eq!(
-        format!("{:04x?}", BitFlags::<Test>::all()),
+        format!("{:04x?}", Test::ALL),
         "BitFlags<Test>(0x0f, A | B | C | D)"
     );
 
     assert_eq!(
-        format!("{:04X?}", BitFlags::<Test>::all()),
+        format!("{:04X?}", Test::ALL),
         "BitFlags<Test>(0x0F, A | B | C | D)"
     );
 
     // Also check alternate struct formatting
 
     assert_eq!(
-        format!("{:#010?}", BitFlags::<Test>::all()),
+        format!("{:#010?}", Test::ALL),
 "BitFlags<Test> {
     bits: 0b00001111,
     flags: A | B | C | D,
@@ -39,7 +39,7 @@ fn debug_format() {
     );
 
     assert_eq!(
-        format!("{:#?}", BitFlags::<Test>::empty()),
+        format!("{:#?}", Test::EMPTY),
 "BitFlags<Test> {
     bits: 0b0,
 }"
@@ -48,27 +48,27 @@ fn debug_format() {
 
 #[test]
 fn format() {
-    use enumflags2::BitFlags;
+    use enumflags2::BitFlagExtConst;
 
     // Assert BitFlags<T> impls fmt::{Binary, Octal, LowerHex, UpperHex}
 
     assert_eq!(
-        format!("{:b}", BitFlags::<Test>::all()),
+        format!("{:b}", Test::ALL),
         "1111"
     );
 
     assert_eq!(
-        format!("{:o}", BitFlags::<Test>::all()),
+        format!("{:o}", Test::ALL),
         "17"
     );
 
     assert_eq!(
-        format!("{:x}", BitFlags::<Test>::all()),
+        format!("{:x}", Test::ALL),
         "f"
     );
 
     assert_eq!(
-        format!("{:#04X}", BitFlags::<Test>::all()),
+        format!("{:#04X}", Test::ALL),
         "0x0F"
     );
 }

--- a/test_suite/tests/no_implicit_prelude.rs
+++ b/test_suite/tests/no_implicit_prelude.rs
@@ -15,6 +15,6 @@ pub enum Test {
 #[test]
 fn test_foo() {
     // assert!() doesn't even work in no_implicit_prelude!
-    use enumflags2::BitFlags;
-    let _ = BitFlags::<Test>::all();
+    use enumflags2::BitFlagExtConst;
+    let _ = Test::ALL;
 }

--- a/test_suite/tests/no_implicit_prelude_2018.rs
+++ b/test_suite/tests/no_implicit_prelude_2018.rs
@@ -12,6 +12,6 @@ pub enum Test {
 #[test]
 fn test_foo() {
     // assert!() doesn't even work in no_implicit_prelude!
-    use ::enumflags2::BitFlags;
-    let _ = BitFlags::<Test>::all();
+    use ::enumflags2::BitFlagExtConst;
+    let _ = Test::ALL;
 }


### PR DESCRIPTION
I started considering the awkwardness around the `BitFlags<T>` type and why the `RawBitFlags` trait couldn't just be a stable/public API and then this happened. Not sure what to think really, moving everything to a trait just makes a prelude / `*` import necessary but offers a way to reason about generic flags:

- `BitFlagRepr<T>` as a trait encompasses a low-level typed set (or subset) of flags. This is typically either a `BitFlags<T>` (which can hold any of no flags, all flags, or anywhere in between) or a bitflags enum (which can hold exactly one flag). It's responsible for conversions to/from an underlying numeric primitive.
- `BitFlag` is the trait that gets impl'd for the single flag type / the enum, which basically serves the same purpose as `RawBitFlags` does today except it gets extended with a few extensions:
    - It impls `BitFlagRepr` so offers conversions to/from the underlying integer representation (like say `from_bit` for the enum type)
    - It has an associated `Self::Flags` type that can hold a set/collection of flags, to enable things like `Enum::ALL` instead of `BitFlags::<Enum>::all()` and basically just, helper extensions for constructing / referring to a `BitFlags<Enum>`.
- `EnumFlags` (which really should be called `BitFlags` for consistency?) is a generic trait describing a set of `BitFlag`s. Most of the `BitFlags` logic was moved here.
- `BitFlags<T>` impl's `BitFlagsRepr` and `EnumFlags` and serves the same purpose as it does now, except it's been gutted with all functionality actually implemented in the trait.

I have no real goals in mind (yet?), just wanted to reason about things generically and see what happened. I guess partial motivation is in wanting to see if it's feasible to support arbitrary flag structures that aren't tied to a `repr(X)`, as I just remembered I've needed to do in the past with [bitmask arrays](https://github.com/arcnmx/input-linux-rs/blob/master/src/bitmask.rs) that are indexable using [rather large enums](https://github.com/arcnmx/input-linux-rs/blob/master/src/keys.rs) (and thus `1 << discriminator` instead).