### PR TITLE
RFC: derive: reexport empty() and all() for extra convenience

### DIFF
--- a/enumflags_derive/src/lib.rs
+++ b/enumflags_derive/src/lib.rs
@@ -218,6 +218,16 @@ fn gen_enumflags(ident: &Ident, item: &DeriveInput, data: &DataEnum)
                 }
             }
 
+            impl #ident {
+                fn empty() -> ::enumflags2::BitFlags<#ident> {
+                    ::enumflags2::BitFlags::empty()
+                }
+
+                fn all() -> ::enumflags2::BitFlags<#ident> {
+                    ::enumflags2::BitFlags::all()
+                }
+            }
+
             impl ::enumflags2::_internal::RawBitFlags for #ident {
                 type Type = #ty;
 

--- a/test_suite/common.rs
+++ b/test_suite/common.rs
@@ -58,6 +58,9 @@ fn test_foo() {
         assert_eq!(b, Test::A | Test::C);
     }
     assert_eq!((Test::A ^ Test::B), Test::A | Test::B);
+
+    assert_eq!(Test::empty(), BitFlags::<Test>::empty());
+    assert_eq!(Test::all(), BitFlags::<Test>::all());
 }
 
 #[test]


### PR DESCRIPTION
Arguably, this may conflict with user defined functions, so either we
should make it optional or declare API break?

Fixes #25 