### PR TITLE
Proposal for (limited) `const BitFlags<T>` API

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,9 @@ edition = "2018"
 version = "=0.7.0-preview1"
 path = "enumflags_derive"
 
+[dependencies.rustversion]
+version = "1.0"
+
 [dependencies.serde]
 version = "^1.0.0"
 default-features = false

--- a/enumflags_derive/src/lib.rs
+++ b/enumflags_derive/src/lib.rs
@@ -277,11 +277,13 @@ fn gen_enumflags(ast: &ItemEnum)
 
             impl ::enumflags2::BitFlag for #ident {}
 
+            #[::enumflags2::rustversion::since(1.46)]
             impl ::enumflags2::ConstBitFlags<#ident> for ::enumflags2::BitFlags<#ident> {
                 const FLAG_LIST_AS_BITFLAGS: &'static [::enumflags2::BitFlags<#ident>] =
                     &[#(unsafe { #std_path::mem::transmute::<#ty, ::enumflags2::BitFlags::<#ident>>(#repeated_name::#variant_names as #ty) }),*];
             }
 
+            #[::enumflags2::rustversion::since(1.46)]
             impl #ident {
                 const fn as_bitflags(&self) -> ::enumflags2::BitFlags<#ident> {
                     match self {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -565,3 +565,32 @@ mod impl_serde {
         }
     }
 }
+
+/// Convenient macro to initialize const `BitFlags`.
+///
+/// ```
+/// # use enumflags2::{bitflags, BitFlags, const_bitflags};
+/// #[bitflags]
+/// #[repr(u8)]
+/// #[derive(Clone, Copy, Debug, PartialEq, Eq)]
+/// enum MyFlag {
+///     A = 1 << 0,
+///     B = 1 << 1,
+///     C = 1 << 2,
+/// }
+///
+/// const FLAGS_AC: BitFlags<MyFlag> = const_bitflags!(MyFlag::{ A | C });
+/// assert_eq!(FLAGS_AC, MyFlag::A | MyFlag::C);
+/// ```
+#[macro_export]
+macro_rules! const_bitflags {
+    ( $enum_ident:ident :: { $(|)? $($variant:ident)|* })=>{{
+        let mut value = <$enum_ident as $crate::_internal::RawBitFlags>::EMPTY;
+
+        $(
+            value |= $enum_ident::$variant as <$enum_ident as $crate::_internal::RawBitFlags>::Type;
+        )*
+
+        unsafe { ::core::mem::transmute::<<$enum_ident as $crate::_internal::RawBitFlags>::Type, $crate::BitFlags::<$enum_ident>>(value) }
+    }};
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -210,7 +210,7 @@ pub mod _internal {
 
     // Re-export libcore so the macro doesn't inject "extern crate" downstream.
     pub mod core {
-        pub use core::{convert, option, ops};
+        pub use core::{convert, mem, option, ops};
     }
 
     pub struct AssertionSucceeded;
@@ -418,6 +418,12 @@ where
     pub fn iter(self) -> impl Iterator<Item = T> {
         T::FLAG_LIST.iter().cloned().filter(move |&flag| self.contains(flag))
     }
+}
+
+/// A trait to manipulate `const BitFlags<T>`
+pub trait ConstBitFlags<T: BitFlag> {
+    /// A slice that contains each variant as a `BitFlags<T>` exactly one.
+    const FLAG_LIST_AS_BITFLAGS: &'static [BitFlags<T>];
 }
 
 impl<T, B> cmp::PartialEq<B> for BitFlags<T>

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -92,6 +92,9 @@ extern crate enumflags2_derive;
 #[doc(hidden)]
 pub use enumflags2_derive::bitflags_internal as bitflags;
 
+#[doc(hidden)]
+pub use rustversion;
+
 /// A trait automatically implemented by `#[bitflags]` to make the enum
 /// a valid type parameter for `BitFlags<T>`.
 pub trait BitFlag: Copy + Clone + 'static + _internal::RawBitFlags {
@@ -582,6 +585,7 @@ mod impl_serde {
 /// const FLAGS_AC: BitFlags<MyFlag> = const_bitflags!(MyFlag::{ A | C });
 /// assert_eq!(FLAGS_AC, MyFlag::A | MyFlag::C);
 /// ```
+#[rustversion::since(1.46)]
 #[macro_export]
 macro_rules! const_bitflags {
     ( $enum_ident:ident :: { $(|)? $($variant:ident)|* })=>{{

--- a/test_suite/Cargo.toml
+++ b/test_suite/Cargo.toml
@@ -12,6 +12,7 @@ version = "1"
 features = ["derive"]
 
 [dev-dependencies]
+rustversion = "1.0"
 trybuild = "1.0"
 
 [[test]]

--- a/test_suite/common.rs
+++ b/test_suite/common.rs
@@ -118,6 +118,7 @@ fn module() {
     }
 }
 
+#[rustversion::since(1.46)]
 #[test]
 fn test_const() {
     use enumflags2::{BitFlags, const_bitflags};

--- a/test_suite/common.rs
+++ b/test_suite/common.rs
@@ -117,3 +117,26 @@ fn module() {
         }
     }
 }
+
+#[test]
+fn test_const() {
+    use enumflags2::{BitFlags, const_bitflags};
+
+    const TEST_A: BitFlags<Test> = Test::A.as_bitflags();
+    const TEST_B: BitFlags<Test> = Test::B.as_bitflags();
+    const TEST_C: BitFlags<Test> = Test::C.as_bitflags();
+    const TEST_D: BitFlags<Test> = Test::D.as_bitflags();
+
+    assert_eq!(TEST_A, BitFlags::<Test>::from_flag(Test::A));
+    assert_eq!(TEST_B, BitFlags::<Test>::from_flag(Test::B));
+    assert_eq!(TEST_C, BitFlags::<Test>::from_flag(Test::C));
+    assert_eq!(TEST_D, BitFlags::<Test>::from_flag(Test::D));
+
+    const TEST_AC: BitFlags<Test> = const_bitflags!(Test::{ A | C });
+
+    assert_eq!(TEST_AC, Test::A | Test::C);
+
+    const TEST_ALL: BitFlags<Test> = const_bitflags!(Test::{ A | B | C | D });
+
+    assert_eq!(TEST_ALL, BitFlags::<Test>::all());
+}


### PR DESCRIPTION
This is a proposal for a limited API to construct `const BitFlags<T>`

This adds two things:

1. A `T::as_bitflags()` (naming to be decided) method for each `enum` that is derived in order to build simple `const BitFlags<T>` values. This does not allow to build complex values by composing different flags but is still valuable for simple values in order not to rely on a macro rule (see next point) and can be used inside `const` functions:

```
use enumflags2::{bitflags, BitFlags, const_bitflags};

#[bitflags]
#[derive(Copy, Clone, Debug, PartialEq)]
#[repr(u8)]
enum Test {
    A = 1 << 0,
    B = 1 << 1,
    C = 1 << 2,
    D = 1 << 3,
}

const TEST_A: BitFlags<Test> = Test::A.as_bitflags();
assert_eq!(TEST_A, BitFlags::<Test>::from_flag(Test::A));
```

2. A `const_bitflags` macro rule (naming to be decided) that allows to build complex `const BitFlags<T>` but only outside of functions. This is intended to be used to declare global const values:

```
use enumflags2::{bitflags, BitFlags, const_bitflags};

#[bitflags]
#[derive(Copy, Clone, Debug, PartialEq)]
#[repr(u8)]
enum Test {
    A = 1 << 0,
    B = 1 << 1,
    C = 1 << 2,
    D = 1 << 3,
}

const TEST_AC: BitFlags<Test> = const_bitflags!(Test::{ A | C });
assert_eq!(TEST_AC, Test::A | Test::C);
```

Implementation details:

This work rely on the fact that `BitFlags<T>` is annotated with `#[repr(transparent)]` which allows for legally transmuting (while still being unsafe) a value to its inner type. This property is useful to build `const BitFlags<T>` while not exposing publicly its inner `val` member. Transmuting outside of `const fn` has been stable since rust `1.46`.

See also issue #30 