### PR TITLE
Mark the result of BitFlags::iter as Clone

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -601,7 +601,7 @@ where
     }
 
     /// Returns an iterator that yields each set flag
-    pub fn iter(self) -> impl Iterator<Item = T> {
+    pub fn iter(self) -> impl Iterator<Item = T> + Clone {
         T::FLAG_LIST
             .iter()
             .cloned()

--- a/test_suite/common.rs
+++ b/test_suite/common.rs
@@ -87,6 +87,9 @@ fn iterator() {
 
     for &(bitflag, expected) in tests {
         assert!(bitflag.iter().zip(expected.iter().cloned()).all(|(a, b)| a == b));
+        // If cloned, the iterator will yield the same elements.
+        let it = bitflag.iter();
+        assert_eq!(it.clone().collect::Vec<_>(), it.collect::Vec<_>());
     }
 }
 

--- a/test_suite/common.rs
+++ b/test_suite/common.rs
@@ -89,7 +89,7 @@ fn iterator() {
         assert!(bitflag.iter().zip(expected.iter().cloned()).all(|(a, b)| a == b));
         // If cloned, the iterator will yield the same elements.
         let it = bitflag.iter();
-        assert_eq!(it.clone().collect::Vec<_>(), it.collect::Vec<_>());
+        assert_eq!(it.clone().collect::<Vec<_>>(), it.collect::<Vec<_>>());
     }
 }
 

--- a/test_suite/common.rs
+++ b/test_suite/common.rs
@@ -89,7 +89,7 @@ fn iterator() {
         assert!(bitflag.iter().zip(expected.iter().cloned()).all(|(a, b)| a == b));
         // If cloned, the iterator will yield the same elements.
         let it = bitflag.iter();
-        assert_eq!(it.clone().collect::<Vec<_>>(), it.collect::<Vec<_>>());
+        assert!(it.clone().zip(it).all(|(a, b)| a == b));
     }
 }
 


### PR DESCRIPTION
This is already supported by the implementation but wasn't exposed.