### PR TITLE
Add method to extract single flags

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -230,10 +230,16 @@ pub mod _internal {
         + Copy
         + Clone
     {
+        #[doc(hidden)]
+        fn is_power_of_two(self) -> bool;
     }
 
     for_each_uint! { $ty $hide_docs =>
-        impl BitFlagNum for $ty {}
+        impl BitFlagNum for $ty {
+            fn is_power_of_two(self) -> bool {
+                <$ty>::is_power_of_two(self)
+            }
+        }
     }
 
     // Re-export libcore so the macro doesn't inject "extern crate" downstream.
@@ -267,6 +273,8 @@ pub mod _internal {
         1 << (!x).trailing_zeros()
     }
 }
+
+use _internal::BitFlagNum;
 
 // Internal debug formatting implementations
 mod formatting;
@@ -553,6 +561,16 @@ where
     #[inline(always)]
     pub fn is_empty(self) -> bool {
         self.val == T::EMPTY
+    }
+
+    /// Returns the flag that is set if there is exactly one.
+    #[inline(always)]
+    pub fn to_flag(self) -> Option<T> {
+        if self.val.is_power_of_two() {
+            Some(unsafe { core::mem::transmute_copy(&self.val) })
+        } else {
+            None
+        }
     }
 
     /// Returns the underlying bitwise value.

--- a/test_suite/common.rs
+++ b/test_suite/common.rs
@@ -72,6 +72,10 @@ fn test_foo() {
     assert_eq!((Test::A ^ Test::B), Test::A | Test::B);
 
     assert_eq!(BitFlags::<Default6>::default(), Default6::B | Default6::C);
+
+    assert_eq!(BitFlags::<Test>::empty().to_flag(), None);
+    assert_eq!(BitFlags::<Test>::from(Test::B).to_flag(), Some(Test::B));
+    assert_eq!((Test::A | Test::C).to_flag(), None);
 }
 
 #[test]

--- a/test_suite/common.rs
+++ b/test_suite/common.rs
@@ -30,15 +30,13 @@ enum Default6 {
 }
 
 #[test]
-fn test_foo() {
+fn test_ctors() {
     use enumflags2::BitFlags;
     assert_eq!(
         BitFlags::<Test>::all(),
         Test::A | Test::B | Test::C | Test::D
     );
     assert_eq!(BitFlags::<Test>::all() & Test::A, Test::A);
-    assert_eq!(!Test::A, Test::B | Test::C | Test::D);
-    assert_eq!((Test::A | Test::C) ^ (Test::C | Test::B), Test::A | Test::B);
     assert_eq!(BitFlags::<Test>::from_bits_truncate(4), Test::C);
     assert_eq!(BitFlags::<Test>::from_bits_truncate(5), Test::A | Test::C);
     assert_eq!(
@@ -51,28 +49,41 @@ fn test_foo() {
         BitFlags::<Test>::from_bits(15).unwrap(),
         BitFlags::<Test>::all()
     );
-    {
-        let mut b = Test::A | Test::B;
-        b.insert(Test::C);
-        assert_eq!(b, Test::A | Test::B | Test::C);
-    }
+    assert_eq!((Test::A | Test::B).bits(), 3);
+    assert_eq!((!(Test::A | Test::B)).bits(), 12);
+    assert_eq!(BitFlags::<Test>::all().bits(), 15);
+    assert_eq!(BitFlags::<Default6>::default(), Default6::B | Default6::C);
+}
+
+#[test]
+fn test_ops() {
+    assert_eq!(!Test::A, Test::B | Test::C | Test::D);
+    assert_eq!((Test::A | Test::C) ^ (Test::C | Test::B), Test::A | Test::B);
     assert!((Test::A | Test::B).intersects(Test::B));
     assert!(!(Test::A | Test::B).intersects(Test::C));
     assert!((Test::A | Test::B | Test::C).contains(Test::A | Test::B));
     assert!(!(Test::A | Test::B | Test::C).contains(Test::A | Test::D));
     assert_eq!(!(Test::A | Test::B), Test::C | Test::D);
-    assert_eq!((Test::A | Test::B).bits(), 3);
-    assert_eq!((!(Test::A | Test::B)).bits(), 12);
-    assert_eq!(BitFlags::<Test>::all().bits(), 15);
+    assert_eq!((Test::A ^ Test::B), Test::A | Test::B);
+}
+
+#[test]
+fn test_mutation() {
+    {
+        let mut b = Test::A | Test::B;
+        b.insert(Test::C);
+        assert_eq!(b, Test::A | Test::B | Test::C);
+    }
     {
         let mut b = Test::A | Test::B | Test::C;
         b.remove(Test::B);
         assert_eq!(b, Test::A | Test::C);
     }
-    assert_eq!((Test::A ^ Test::B), Test::A | Test::B);
+}
 
-    assert_eq!(BitFlags::<Default6>::default(), Default6::B | Default6::C);
-
+#[test]
+fn test_to_flag() {
+    use enumflags2::BitFlags;
     assert_eq!(BitFlags::<Test>::empty().to_flag(), None);
     assert_eq!(BitFlags::<Test>::from(Test::B).to_flag(), Some(Test::B));
     assert_eq!((Test::A | Test::C).to_flag(), None);


### PR DESCRIPTION
Added the `BitFlags::to_flag` method that converts `BitFlags<T>` to `T` if there is exactly one flag that is set.

This is semantically equivalent to `flags.iter().exactly_one()` with `itertools`, but without the dependency and faster since it can use POPCNT when available.