### PR TITLE
Add optional zerocopy support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,8 +20,18 @@ version = "^1.0.0"
 default-features = false
 optional = true
 
+[dependencies.zerocopy]
+version = "0.8.9"
+default-features = false
+optional = true
+[dependencies.zerocopy-derive]
+version = "0.8.9"
+default-features = false
+optional = true
+
 [features]
 std = []
+zerocopy = ["dep:zerocopy", "dep:zerocopy-derive"]
 
 [workspace]
 members = [

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -253,7 +253,7 @@ pub trait BitFlag: Copy + Clone + 'static + _internal::RawBitFlags {
     ///
     /// All bits set in `val` must correspond to a value of the enum.
     ///
-    /// # Example 
+    /// # Example
     ///
     /// This is a convenience reexport of [`BitFlags::from_bits_unchecked`]. It can be
     /// called with `MyFlag::from_bits_unchecked(bits)`, thus bypassing the need for
@@ -322,8 +322,8 @@ pub mod _internal {
     }
 
     use ::core::fmt;
-    use ::core::ops::{BitAnd, BitOr, BitXor, Not, Sub};
     use ::core::hash::Hash;
+    use ::core::ops::{BitAnd, BitOr, BitXor, Not, Sub};
 
     pub trait BitFlagNum:
         Default

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1082,6 +1082,10 @@ mod impl_zerocopy {
         T::Numeric: Immutable,
         T::Numeric: FromZeros,
     {
+        // We are actually allowed to implement this trait. The scary name is just meant
+        // to convey that "this is dangerous and you'd better know what you're doing and
+        // be sure that you need to do this and can't just use the derives". (https://github.com/google/zerocopy/issues/287)
+        // We can not use the derives for this, because they dont support validation.
         fn only_derive_is_allowed_to_implement_this_trait() {}
     }
 
@@ -1091,6 +1095,10 @@ mod impl_zerocopy {
         T: BitFlag,
         T::Numeric: Unaligned,
     {
+        // We are actually allowed to implement this trait. The scary name is just meant
+        // to convey that "this is dangerous and you'd better know what you're doing and
+        // be sure that you need to do this and can't just use the derives". (https://github.com/google/zerocopy/issues/287)
+        // We can not use the derives for this, because they dont support validation.
         fn only_derive_is_allowed_to_implement_this_trait() {}
     }
 
@@ -1101,6 +1109,10 @@ mod impl_zerocopy {
         T::Numeric: Immutable,
         T::Numeric: TryFromBytes,
     {
+        // We are actually allowed to implement this trait. The scary name is just meant
+        // to convey that "this is dangerous and you'd better know what you're doing and
+        // be sure that you need to do this and can't just use the derives". (https://github.com/google/zerocopy/issues/287)
+        // We can not use the derives for this, because they dont support validation.
         fn only_derive_is_allowed_to_implement_this_trait()
         where
             Self: Sized,

--- a/test_suite/Cargo.toml
+++ b/test_suite/Cargo.toml
@@ -6,10 +6,14 @@ edition = "2018"
 
 [dependencies.enumflags2]
 path = "../"
-features = ["serde"]
+features = ["serde", "zerocopy"]
 
 [dependencies.serde]
 version = "1"
+features = ["derive"]
+
+[dependencies.zerocopy]
+version = "0.8.9"
 features = ["derive"]
 
 [dev-dependencies]
@@ -64,4 +68,9 @@ edition = "2018"
 [[test]]
 name = "not_literal"
 path = "tests/not_literal.rs"
+edition = "2018"
+
+[[test]]
+name = "zerocopy"
+path = "tests/zerocopy.rs"
 edition = "2018"

--- a/test_suite/tests/zerocopy.rs
+++ b/test_suite/tests/zerocopy.rs
@@ -1,0 +1,32 @@
+use enumflags2::{bitflags, BitFlags};
+use zerocopy::{Immutable, IntoBytes, KnownLayout, TryFromBytes};
+
+#[test]
+fn zerocopy_compile() {
+    #[bitflags]
+    #[derive(Copy, Clone, Debug, KnownLayout)]
+    #[repr(u8)]
+    enum TestU8 {
+        A,
+        B,
+        C,
+        D,
+    }
+
+    #[bitflags]
+    #[derive(Copy, Clone, Debug, KnownLayout)]
+    #[repr(u16)]
+    enum TestU16 {
+        A,
+        B,
+        C,
+        D,
+    }
+
+    #[derive(Clone, Debug, Immutable, TryFromBytes, IntoBytes, KnownLayout)]
+    #[repr(packed)]
+    struct Other {
+        flags2: BitFlags<TestU8>,
+        flags: BitFlags<TestU16>,
+    }
+}


### PR DESCRIPTION
This PR adds a flag that enables implementations for [zerocopy](https://github.com/google/zerocopy) traits on BitFlags.

Converting a `BitFlags` into the underlying number is trivial and always safe, so we can just derive those traits. Converting from a number to `BitFlags` is more tricky, because not every bit-pattern is valid. To assert that the bit-pattern is valid this PR provides a custom implementation of the `zerocopy::TryFromBytes` trait. Custom implementations for zerocopy traits `TryFromBytes` seem [somewhat discouraged but supported](https://github.com/google/zerocopy/issues/287), so it should be fine to implement that.