### PR TITLE
Use fully-qualified path to refer to the associated type

### DIFF
--- a/enumflags_derive/src/lib.rs
+++ b/enumflags_derive/src/lib.rs
@@ -334,18 +334,18 @@ fn gen_enumflags(ast: &mut DeriveInput, default: Vec<Ident>) -> Result<TokenStre
             unsafe impl ::enumflags2::_internal::RawBitFlags for #ident {
                 type Numeric = #repr;
 
-                const EMPTY: Self::Numeric = 0;
+                const EMPTY: <Self as ::enumflags2::_internal::RawBitFlags>::Numeric = 0;
 
-                const DEFAULT: Self::Numeric =
+                const DEFAULT: <Self as ::enumflags2::_internal::RawBitFlags>::Numeric =
                     0 #(| (Self::#default as #repr))*;
 
-                const ALL_BITS: Self::Numeric =
+                const ALL_BITS: <Self as ::enumflags2::_internal::RawBitFlags>::Numeric =
                     0 #(| (Self::#variant_names as #repr))*;
 
                 const BITFLAGS_TYPE_NAME : &'static str =
                     concat!("BitFlags<", stringify!(#ident), ">");
 
-                fn bits(self) -> Self::Numeric {
+                fn bits(self) -> <Self as ::enumflags2::_internal::RawBitFlags>::Numeric {
                     self as #repr
                 }
             }

--- a/test_suite/common.rs
+++ b/test_suite/common.rs
@@ -29,6 +29,14 @@ enum Default6 {
     D = 1 << 3,
 }
 
+#[bitflags]
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
+#[repr(u8)]
+enum AssociatedTypeNameConflict {
+    Stringy = 1 << 0,
+    Numeric = 1 << 1,
+}
+
 #[test]
 fn test_ctors() {
     use enumflags2::BitFlags;


### PR DESCRIPTION
Prevent "ambiguous associated type" if one of the variants is named `Numeric`.